### PR TITLE
Fix for issue with files with same name

### DIFF
--- a/lib/src/main/java/aga/library/picassos3/DiskCache.java
+++ b/lib/src/main/java/aga/library/picassos3/DiskCache.java
@@ -138,7 +138,7 @@ final class DiskCache {
     }
 
     private String toKey(@NonNull final Uri uri) {
-        final String key = uri.getLastPathSegment().toLowerCase();
+        final String key = uri.getPath().toLowerCase()
         final String cleanKey = key.replaceAll("[^a-zA-Z0-9]", "");
         final int length = cleanKey.length();
 


### PR DESCRIPTION
The current implementation of key breaks for different URLs having same file name. The suggested edit makes the key independent of file name by adding URL to the file name.